### PR TITLE
StateMachine Errors

### DIFF
--- a/lib/state_machine.ex
+++ b/lib/state_machine.ex
@@ -62,23 +62,23 @@ defmodule StateMachine do
   * With Ecto support activated every transition is wrapped in transaction
   * With Ecto support activated the Ecto.Type implementation is generated automatically
   """
-  alias StateMachine.{State, Event, Context}
+  alias StateMachine.{Context, Error, Event, State, Event}
 
   @type t(m) :: %__MODULE__{
-    states: %{optional(atom) => State.t(m)},
-    events: %{optional(atom) => Event.t(m)},
-    field:  atom(),
+    states:       %{optional(atom) => State.t(m)},
+    events:       %{optional(atom) => Event.t(m)},
+    field:        atom(),
     state_getter: (Context.t(m) -> atom()),
-    state_setter: (Context.t(m), atom() -> Context.t(m)),
-    misc: keyword()
+    state_setter: (Context.t(m), atom() -> {:ok, Context.t(m)} | {:error, Error.SetError.t(m)}),
+    misc:         keyword()
   }
 
   defstruct states: %{},
-    events: %{},
-    field: :state,
-    state_getter: &State.get/1,
-    state_setter: &State.set/2,
-    misc: []
+    events:         %{},
+    field:          :state,
+    state_getter:   &State.get/1,
+    state_setter:   &State.set/2,
+    misc:           []
 
   defmacro __using__(_) do
     quote do

--- a/lib/state_machine/context.ex
+++ b/lib/state_machine/context.ex
@@ -12,7 +12,6 @@ defmodule StateMachine.Context do
     definition: StateMachine.t(model),
     model: model,
     status: :init | :failed | :done,
-    error: any,
     event: atom,
     transition: Transition.t(model) | nil,
     payload: any
@@ -23,7 +22,6 @@ defmodule StateMachine.Context do
     :definition,
     :model,
     {:status, :init},
-    :error,
     :event,
     :transition,
     :payload

--- a/lib/state_machine/dsl.ex
+++ b/lib/state_machine/dsl.ex
@@ -280,8 +280,8 @@ defmodule StateMachine.DSL do
     quote do
       def trigger(model, event, payload \\ nil) do
         case trigger_with_context(model, event, payload) do
-          %Context{status: :done, model: model} -> {:ok, model}
-          %Context{error: m} -> {:error, m}
+          {:ok, %Context{status: :done, model: model}} -> {:ok, model}
+          {:error, error} -> {:error, error}
         end
       end
     end
@@ -294,8 +294,8 @@ defmodule StateMachine.DSL do
         repo = __state_machine__().misc[:repo]
         repo.transaction fn ->
           case trigger_with_context(model, event, payload) do
-            %Context{status: :done, model: model} -> model
-            %Context{error: m} -> repo.rollback(m)
+            {:ok, %Context{status: :done, model: model}} -> model
+            {:error, error} -> repo.rollback(error)
           end
         end
       end

--- a/lib/state_machine/ecto.ex
+++ b/lib/state_machine/ecto.ex
@@ -97,9 +97,9 @@ defmodule StateMachine.Ecto do
     |> ctx.definition.misc[:repo].update()
     |> case do
       {:ok, model} ->
-        %{ctx | model: model}
+        {:ok, %{ctx | model: model}}
       {:error, e} ->
-        %{ctx | status: :failed, message: {:set_state, e}}
+        {:error, %StateMachine.Error.SetError{context: ctx, error: e}}
     end
   end
 end

--- a/lib/state_machine/error/callback_error.ex
+++ b/lib/state_machine/error/callback_error.ex
@@ -1,0 +1,19 @@
+#TODO Maybe should rename the module
+defmodule StateMachine.Error.CallbackError do
+  @moduledoc """
+  CallbackError is a container for the metadata needed to understand why сallback is failed.
+  """
+
+  @type t(model) :: %__MODULE__{
+    context: StateMachine.Context.t(model),
+    step: atom,
+    error: any
+  }
+
+  @enforce_keys [:context, :step, :error]
+  defstruct [
+    :context,
+    :step,
+    :error
+  ]
+end

--- a/lib/state_machine/error/guard_not_allow.ex
+++ b/lib/state_machine/error/guard_not_allow.ex
@@ -1,0 +1,16 @@
+defmodule StateMachine.Error.GuardNotAllow do
+  @moduledoc """
+  GuardNotAllow is a container for the metadata needed to understand why guard didn't allow event.
+  """
+
+  @type t(model) :: %__MODULE__{
+    context: StateMachine.Context.t(model),
+    event: atom
+  }
+
+  @enforce_keys [:context, :event]
+  defstruct [
+    :context,
+    :event
+  ]
+end

--- a/lib/state_machine/error/set_error.ex
+++ b/lib/state_machine/error/set_error.ex
@@ -1,0 +1,17 @@
+#TODO Maybe should rename the module
+defmodule StateMachine.Error.SetError do
+  @moduledoc """
+  SetError is a container for the metadata needed to understand why set model to state is failed.
+  """
+
+  @type t(model) :: %__MODULE__{
+    context: StateMachine.Context.t(model),
+    error: any
+  }
+
+  @enforce_keys [:context, :error]
+  defstruct [
+    :context,
+    :error
+  ]
+end

--- a/lib/state_machine/error/unknown_event.ex
+++ b/lib/state_machine/error/unknown_event.ex
@@ -1,0 +1,16 @@
+defmodule StateMachine.Error.UnknownEvent do
+  @moduledoc """
+  UnknownEvent is a container for the metadata needed to understand the state after an unknown event.
+  """
+
+  @type t(model) :: %__MODULE__{
+    context: StateMachine.Context.t(model),
+    event: atom
+  }
+
+  @enforce_keys [:context, :event]
+  defstruct [
+    :context,
+    :event
+  ]
+end

--- a/lib/state_machine/error/unresolved_transition.ex
+++ b/lib/state_machine/error/unresolved_transition.ex
@@ -1,0 +1,16 @@
+defmodule StateMachine.Error.UnresolvedTransition do
+  @moduledoc """
+  UnresolvedTransition is a container for the metadata needed to understand why transition is unresolved.
+  """
+
+  @type t(model) :: %__MODULE__{
+    context: StateMachine.Context.t(model),
+    event: atom
+  }
+
+  @enforce_keys [:context, :event]
+  defstruct [
+    :context,
+    :event
+  ]
+end

--- a/lib/state_machine/event.ex
+++ b/lib/state_machine/event.ex
@@ -7,14 +7,14 @@ defmodule StateMachine.Event do
   from the same state, but it doesn't guarantee anything: if guards always return true, we're back to where we were before.
   """
 
-  alias StateMachine.{Event, Transition, Context, Callback, Guard}
+  alias StateMachine.{Callback, Context, Error, Event, Guard, Transition}
 
   @type t(model) :: %__MODULE__{
     name:         atom,
     transitions:  list(Transition.t(model)),
     before:       list(Callback.t(model)),
     after:        list(Callback.t(model)),
-    guards:       list(Guard.t(model)),
+    guards:       list(Guard.t(model))
   }
 
   @type callback_pos() :: :before | :after
@@ -35,7 +35,7 @@ defmodule StateMachine.Event do
   """
   @spec is_allowed?(Context.t(model), t(model) | atom) :: boolean when model: var
   def is_allowed?(ctx, event) do
-    !is_nil(find_transition(ctx, event))
+    :ok == guard_check(ctx, event) and match?({:ok, _}, find_transition(ctx, event))
   end
 
   @doc """
@@ -43,34 +43,65 @@ defmodule StateMachine.Event do
   and optional payload, you tell state machine to try to move to the next state.
   It returns an updated context.
   """
-  @spec trigger(Context.t(model), atom, any) :: Context.t(model) when model: var
+  @type errors(model) ::
+          Error.GuardNotAllow.t(model)
+          | Error.UnresolvedTransition.t(model)
+          | Error.UnknownEvent.t(model)
+          | Error.CallbackError.t(model)
+
+  @spec trigger(Context.t(model), atom, any) :: {:ok, Context.t(model)} | {:error, errors(model)}
+        when model: var
   def trigger(ctx, event, payload \\ nil) do
     context = %{ctx | payload: payload, event: event}
-    with {_, %Event{} = e} <- {:event, Map.get(context.definition.events, event)},
-      {_, %Transition{} = t} <- {:transition, find_transition(context, e)}
-    do
+
+    with {:ok, %Event{} = e} <- find_event(context, event),
+         :ok <- guard_check(context, e),
+         {:ok, %Transition{} = t} <- find_transition(context, e) do
       Transition.run(%{context | transition: t})
-    else
-      {item, _} -> %{context | status: :failed, error: {item, "Couldn't resolve #{item}"}}
     end
   end
 
   @doc """
   Private function for running Event callbacks.
   """
-  @spec callback(Context.t(model), callback_pos()) :: Context.t(model) when model: var
+  @spec callback(Context.t(model), callback_pos()) ::
+          {:ok, Context.t(model)} | {:error, Error.CallbackError.t(model)}
+        when model: var
   def callback(ctx, pos) do
     callbacks = Map.get(ctx.definition.events[ctx.event], pos)
     Callback.apply_chain(ctx, callbacks, :"#{pos}_event")
   end
 
-  @spec find_transition(Context.t(model), t(model)) :: Transition.t(model) | nil when model: var
+  @spec guard_check(Context.t(model), t(model)) ::
+          :ok | {:error, Error.GuardNotAllow.t(model)}
+        when model: var
+  defp guard_check(ctx, event) do
+    if Guard.check(ctx, event),
+      do: :ok,
+      else: {:error, %Error.GuardNotAllow{context: ctx, event: event.name}}
+  end
+
+  @spec find_transition(Context.t(model), t(model)) ::
+          {:ok, Transition.t(model)} | {:error, Error.UnresolvedTransition.t(model)}
+        when model: var
   defp find_transition(ctx, event) do
-    if Guard.check(ctx, event) do
-      state = ctx.definition.state_getter.(ctx)
-      Enum.find(event.transitions, fn transition ->
-        transition.from == state && Transition.is_allowed?(ctx, transition)
-      end)
+    state = ctx.definition.state_getter.(ctx)
+    error = {:error, %Error.UnresolvedTransition{context: ctx, event: event.name}}
+
+    Enum.find_value(event.transitions, error, fn transition ->
+      if transition.from == state && Transition.is_allowed?(ctx, transition) do
+        {:ok, transition}
+      end
+    end)
+  end
+
+  @spec find_event(Context.t(model), atom) ::
+          {:ok, t(model)} | {:error, Error.UnknownEvent.t(model)}
+        when model: var
+  defp find_event(ctx, event_name) do
+    case Map.get(ctx.definition.events, event_name) do
+      %Event{} = e -> {:ok, e}
+      _ -> {:error, %Error.UnknownEvent{context: ctx, event: event_name}}
     end
   end
 end

--- a/lib/state_machine/state.ex
+++ b/lib/state_machine/state.ex
@@ -7,17 +7,19 @@ defmodule StateMachine.State do
   The state get/setters for basic structures and Ecto records are provided out of the box.
   """
 
-  alias StateMachine.{Context, Callback, Transition}
+  alias StateMachine.{Callback, Context, Error, Transition}
 
   @callback get(ctx :: Context.t(any)) :: atom()
-  @callback set(ctx :: Context.t(model), state :: atom) :: Context.t(model) when model: var
+  @callback set(ctx :: Context.t(model), state :: atom) ::
+              {:ok, Context.t(model)} | {:error, Error.SetError.t(model)}
+            when model: var
 
   @type t(model) :: %__MODULE__{
-    name:  atom,
+    name:         atom,
     before_enter: list(Callback.t(model)),
-    after_enter: list(Callback.t(model)),
+    after_enter:  list(Callback.t(model)),
     before_leave: list(Callback.t(model)),
-    after_leave: list(Callback.t(model))
+    after_leave:  list(Callback.t(model))
   }
 
   @type callback_pos() :: :before_enter | :after_enter | :before_leave | :after_leave
@@ -26,20 +28,22 @@ defmodule StateMachine.State do
   defstruct [
     :name,
     before_enter: [],
-    after_enter: [],
+    after_enter:  [],
     before_leave: [],
-    after_leave: []
+    after_leave:  []
   ]
 
   @doc """
   Private function for running state callbacks.
   """
-  @spec callback(Context.t(model), callback_pos()) :: Context.t(model) when model: var
+  @spec callback(Context.t(model), callback_pos()) ::
+          {:ok, Context.t(model)} | {:error, Error.CallbackError.t(model)}
+        when model: var
   def callback(ctx, pos) do
     if Transition.loop?(ctx.transition) do
-      ctx
+      {:ok, ctx}
     else
-      source = String.ends_with?(to_string(pos), "_enter") && :to || :from
+      source = (String.ends_with?(to_string(pos), "_enter") && :to) || :from
       state_name = Map.get(ctx.transition, source)
       state = ctx.definition.states[state_name]
       Callback.apply_chain(ctx, Map.get(state, pos), pos)
@@ -57,8 +61,8 @@ defmodule StateMachine.State do
   @doc """
   Default implementation of a state setter.
   """
-  @spec set(Context.t(model), atom()) :: Context.t(model) when model: var
+  @spec set(Context.t(model), atom()) :: {:ok, Context.t(model)} when model: var
   def set(ctx, state) do
-    %{ctx | model: Map.put(ctx.model, ctx.definition.field, state)}
+    {:ok, %{ctx | model: Map.put(ctx.model, ctx.definition.field, state)}}
   end
 end

--- a/lib/state_machine/transition.ex
+++ b/lib/state_machine/transition.ex
@@ -4,7 +4,7 @@ defmodule StateMachine.Transition do
   around transition from the old state to the new state in response to an event.
   """
 
-  alias StateMachine.{Transition, Event, State, Context, Callback, Guard}
+  alias StateMachine.{Callback, Context, Error, Event, Guard, State, Transition}
 
   @type t(model) :: %__MODULE__{
     from:   atom,
@@ -49,25 +49,28 @@ defmodule StateMachine.Transition do
 
   If any of the callbacks fails, all sequential ops are cancelled.
   """
-  @spec run(Context.t(model)) :: Context.t(model) when model: var
+  @spec run(Context.t(model)) :: {:ok, Context.t(model)} | {:error, Error.CallbackError.t(model)}  when model: var
   def run(ctx) do
-    ctx
-    |> Event.callback(:before)
-    |> Transition.callback(:before)
-    |> State.callback(:before_leave)
-    |> State.callback(:before_enter)
-    |> Transition.update_state()
-    |> State.callback(:after_leave)
-    |> State.callback(:after_enter)
-    |> Transition.callback(:after)
-    |> Event.callback(:after)
-    |> Transition.finalize()
+    with {:ok, ctx} <- Event.callback(ctx, :before),
+         {:ok, ctx} <- Transition.callback(ctx, :before),
+         {:ok, ctx} <- State.callback(ctx, :before_leave),
+         {:ok, ctx} <- State.callback(ctx, :before_enter),
+         {:ok, ctx} <- Transition.update_state(ctx),
+         {:ok, ctx} <- State.callback(ctx, :after_leave),
+         {:ok, ctx} <- State.callback(ctx, :after_enter),
+         {:ok, ctx} <- Transition.callback(ctx, :after),
+         {:ok, ctx} <- Event.callback(ctx, :after),
+         ctx <- Transition.finalize(ctx) do
+      {:ok, ctx}
+    end
   end
 
   @doc """
   Private function for running Transition callbacks.
   """
-  @spec callback(Context.t(model), callback_pos()) :: Context.t(model) when model: var
+  @spec callback(Context.t(model), callback_pos()) ::
+          {:ok, Context.t(model)} | {:error, Error.CallbackError.t(model)}
+        when model: var
   def callback(ctx, pos) do
     callbacks = Map.get(ctx.transition, pos)
     Callback.apply_chain(ctx, callbacks, :"#{pos}_transition")
@@ -76,12 +79,12 @@ defmodule StateMachine.Transition do
   @doc """
   Private function for updating state.
   """
-  @spec update_state(Context.t(model)) :: Context.t(model) when model: var
+  @spec update_state(Context.t(model)) :: {:ok, Context.t(model)} | {:error, Error.SetError.t(model)} when model: var
   def update_state(%{status: :init} = ctx) do
     ctx.definition.state_setter.(ctx, ctx.transition.to)
   end
 
-  def update_state(ctx), do: ctx
+  def update_state(ctx), do: {:ok, ctx}
 
   @doc """
   Private function sets status to :done, unless it has failed before.

--- a/test/state_machine/gen_statem_test.exs
+++ b/test/state_machine/gen_statem_test.exs
@@ -1,5 +1,6 @@
 defmodule StateMachineGenStatemTest do
   use ExUnit.Case, async: true
+  alias StateMachine.Error
 
   defmodule TestMachine do
     use StateMachine
@@ -57,7 +58,7 @@ defmodule StateMachineGenStatemTest do
     refute TestMachine.hungry(cat)
     assert cat.state == :eating
 
-    assert {:error, {:transition, "Couldn't resolve transition"}} = TestMachine.trigger_call(sm, :sing_a_lullaby)
+    assert {:error, %Error.UnresolvedTransition{event: :sing_a_lullaby}} = TestMachine.trigger_call(sm, :sing_a_lullaby)
 
     assert {:ok, %{state: :playing, hungry: false}} = TestMachine.trigger_call(sm, :pet)
     assert {:ok, %{state: :asleep, hungry: true}} = TestMachine.trigger_call(sm, :sing_a_lullaby)


### PR DESCRIPTION
This pull request contains changes that structure errors when the context fails, and also returns information to makes it easier to understand the reason of the error.

- Add errors structures (`CallbackError`, `GuardNotAllow`, `SetError`, `UnknownEvent`, `UnresolvedTransition`). 
- Return error response `{:error, %Error{}}` instead of failed context.


